### PR TITLE
Tags all messages with IDs

### DIFF
--- a/src/detectors/planar-image/planar-image.ts
+++ b/src/detectors/planar-image/planar-image.ts
@@ -16,14 +16,15 @@
  * limitations under the License.
  */
 
-import { DetectableImage } from '../../../defs/detected-image.js';
+import { DetectableImage, DetectedImage } from '../../../defs/detected-image.js';
 import { Marker } from '../../../defs/marker.js';
 import { DEBUG_LEVEL, log } from '../../utils/logger.js';
 
 class Detector {
-  private readonly targets = new Map<number, { id: string }>();
+  private readonly targets = new Map<number, DetectedImage>();
   private isReadyInternal: Promise<void>;
   private worker!: Worker;
+  private workerMessageCallbacks = new Map<string, (data: any) => void>();
 
   constructor(root = '') {
     this.isReadyInternal = new Promise((resolve) => {
@@ -32,7 +33,18 @@ class Detector {
         /* istanbul ignore if */
         if (e.data === 'ready') {
           resolve();
+          return;
         }
+
+        const { msgId, data } = e.data;
+        log(`Message (id: ${msgId}) from worker.`, DEBUG_LEVEL.VERBOSE);
+        const callback = this.workerMessageCallbacks.get(msgId);
+        if (!callback) {
+          return;
+        }
+
+        this.workerMessageCallbacks.delete(msgId);
+        callback.apply(undefined, [data]);
       };
 
       this.worker.postMessage(root);
@@ -53,14 +65,13 @@ class Detector {
 
     return new Promise((resolve) => {
       const startTime = performance.now();
-      this.worker.postMessage({ type: 'process', data });
-      this.worker.onmessage = (e) => {
+      this.send({ type: 'process', data }, (processData: null | number[]) => {
         /* istanbul ignore if */
-        if (e.data === null) {
+        if (processData === null) {
           return [];
         }
 
-        const matches = e.data as number[];
+        const matches = processData as number[];
 
         // Remap to actual target values and filter out empties.
         const ids = matches.map((id) => {
@@ -79,7 +90,7 @@ class Detector {
         resolve(ids);
         log(`Time taken (ms): ${performance.now() - startTime} ` +
             `for ${data.width} * ${data.height}`, DEBUG_LEVEL.VERBOSE);
-      };
+      });
     });
   }
 
@@ -93,24 +104,22 @@ class Detector {
 
   addTarget(data: Uint8Array, image: DetectableImage): Promise<number> {
     return new Promise((resolve) => {
-      this.worker.postMessage({ type: 'add', data, id: image.id });
-      this.worker.onmessage = (e) => {
-        const { idx, id } = e.data;
+      this.send({ type: 'add', data, id: image.id }, (addData: {idx: number, id: string}) => {
+        const { idx, id } = addData;
         this.targets.set(idx as number, { id });
         log(`Target stored: ${id}, number ${idx}`, DEBUG_LEVEL.VERBOSE);
         resolve(idx);
-      };
+      });
     });
   }
 
   removeTarget(data: number): Promise<void> {
     return new Promise((resolve) => {
-      this.worker.postMessage({ type: 'remove', data });
-      this.worker.onmessage = (e) => {
-        this.targets.delete(e.data as number);
-        log(`Target removed: number ${e.data}`, DEBUG_LEVEL.VERBOSE);
+      this.send({ type: 'remove', data }, (removeData: number) => {
+        this.targets.delete(removeData);
+        log(`Target removed: number ${data}`, DEBUG_LEVEL.VERBOSE);
         resolve();
-      };
+      });
     });
   }
 
@@ -121,12 +130,27 @@ class Detector {
 
     this.targets.clear();
     return new Promise((resolve) => {
-      this.worker.postMessage({ type: 'reset' });
-      this.worker.onmessage = (e) => {
+      this.send({ type: 'reset' }, () => {
         log(`Image detector reset`, DEBUG_LEVEL.VERBOSE);
         resolve();
-      };
+      });
     });
+  }
+
+  private send(msg: { type: string, data?: any, id?: string }, callback: (data: any) => void) {
+    const makeRandId = () => {
+      // Array of zeros.
+      return new Array(16).fill(0)
+          // Remapped to random alphanumeric values.
+          .map(() => String.fromCharCode(97 + (Math.random() * 26) | 0))
+          // Joined together.
+          .join('');
+    };
+
+    const msgId = makeRandId();
+    log(`Message (id: ${msgId}, type: ${msg.type}) to worker.`, DEBUG_LEVEL.VERBOSE);
+    this.workerMessageCallbacks.set(msgId, callback);
+    this.worker.postMessage({...msg, msgId});
   }
 }
 

--- a/src/planar/planar-image_worker.ts
+++ b/src/planar/planar-image_worker.ts
@@ -61,7 +61,7 @@ self.onmessage = (e: MessageEvent) => {
   }
 
   const host = (self as any);
-  const { type, data, id } = e.data;
+  const { type, data, id, msgId } = e.data;
 
   switch (type) {
     // Process image data.
@@ -73,31 +73,31 @@ self.onmessage = (e: MessageEvent) => {
           detections.push(processResult.get(r).id);
         }
 
-        host.postMessage(detections);
+        host.postMessage({ msgId, data: detections });
       } catch (e) {
         log(e.message, DEBUG_LEVEL.ERROR);
-        host.postMessage([]);
+        host.postMessage({ msgId, data: [] });
       }
       break;
 
     // Add a target.
     case 'add':
       detector.addDetectionWithId(addCount, data);
-      host.postMessage({ idx: addCount, id });
+      host.postMessage({ msgId, data: { idx: addCount, id } });
       addCount++;
       break;
 
     // Remove a target.
     case 'remove':
       detector.cancelDetection(data);
-      host.postMessage(data);
+      host.postMessage({ msgId, data });
       break;
 
     case 'reset':
       // Currently resetting doesn't do anything on this side, but it may do so
       // this can act as a placeholder for the time being.
       addCount = START_INDEX;
-      host.postMessage({});
+      host.postMessage({ msgId });
       break;
   }
 };


### PR DESCRIPTION
This is a further patch for #126 since it doesn't seem fully resolved. I'm now tagging all outgoing messages to the worker with an ID so we can ensure that the correct callback is executed when the response comes in from the worker. This is on the assumption that worker.onmessage is too brittle for our case, and we have a race condition in terms of which callback is being executed.