### PR TITLE
Refactor MM: `updatePerceptionState` once per-frame 

### DIFF
--- a/defs/detected-image.ts
+++ b/defs/detected-image.ts
@@ -17,11 +17,10 @@
 
 import { MediaObject } from '../src/artifacts/schema/core-schema-org.js';
 
-export interface DetectableImage {
-  id: string;
-  media: MediaObject[];
-}
-
 export interface DetectedImage {
   id: string;
+}
+
+export interface DetectableImage extends DetectedImage {
+  media: MediaObject[];
 }

--- a/demo/custom-artifact-store/index.html
+++ b/demo/custom-artifact-store/index.html
@@ -110,9 +110,9 @@
        * return results if it matches one of the three defined above (`Artifacts` global).
        * 
        */
-      async findRelevantArtifacts(nearbyMarkers, geo, detectedImages) {
+      async findRelevantArtifacts({ markers, geo, images }) {
         const ret = [];
-        for (const marker of nearbyMarkers) {
+        for (const marker of markers) {
           for (const artifact of Artifacts) {
             // If this nearby markers' text matches one of our expected targets, return the artifact.
             if (marker.value === artifact.arTarget.text) {

--- a/src/artifacts/artifact-dealer.ts
+++ b/src/artifacts/artifact-dealer.ts
@@ -43,7 +43,7 @@ export class ArtifactDealer {
   async getPerceptionResults(context: PerceptionState): Promise<PerceptionResult[]> {
     // Set default property values to empty lists, since they are optional.
     // Do this because context may be passed to custom artstores (written in JS) which expect them defined.
-    context = Object.assign({ markers: [], geo: [], images: [] }, context);
+    context = { markers: [], geo: [], images: [], ...context };
 
     // Using current context (geo, markers), ask artstores to compute relevant artifacts
     const allStoreResults = await Promise.all(this.artstores.map((artstore) => {

--- a/src/artifacts/artifact-dealer.ts
+++ b/src/artifacts/artifact-dealer.ts
@@ -17,7 +17,7 @@
 
 import { DetectableImage } from '../../defs/detected-image.js';
 import { flat } from '../utils/flat.js';
-import { ArtifactStore, PerceptionContext, PerceptionResult } from './stores/artifact-store.js';
+import { ArtifactStore, PerceptionResult, PerceptionState } from './stores/artifact-store.js';
 
 export interface PerceptionResultDelta {
   found: PerceptionResult[];
@@ -36,7 +36,7 @@ export class ArtifactDealer {
     this.artstores.push(artstore);
   }
 
-  async getNextFrameContext(request: PerceptionContext): Promise<NextFrameContext> {
+  async getNextFrameContext(request: PerceptionState): Promise<NextFrameContext> {
     const allStoreResults = await Promise.all(this.artstores.map((artstore) => {
       if (!artstore.getDetectableImages) {
         return [];
@@ -46,7 +46,7 @@ export class ArtifactDealer {
     return { detectableImages: flat(allStoreResults) };
   }
 
-  async perceive(context: PerceptionContext): Promise<PerceptionResultDelta> {
+  async updatePerceptionState(context: PerceptionState): Promise<PerceptionResultDelta> {
     // Using current context (geo, markers), ask artstores to compute relevant artifacts
     const allStoreResults = await Promise.all(this.artstores.map((artstore) => {
       if (!artstore.findRelevantArtifacts) {

--- a/src/artifacts/artifact-dealer.ts
+++ b/src/artifacts/artifact-dealer.ts
@@ -24,6 +24,10 @@ export interface PerceptionResultDelta {
   lost: PerceptionResult[];
 }
 
+export interface NextFrameContext {
+  detectableImages: DetectableImage[];
+}
+
 export class ArtifactDealer {
   private readonly artstores: ArtifactStore[] = [];
   private prevPerceptionResults = new Set<PerceptionResult>();
@@ -32,14 +36,14 @@ export class ArtifactDealer {
     this.artstores.push(artstore);
   }
 
-  async getDetectableImages(): Promise<DetectableImage[]> {
+  async getNextFrameContext(request: PerceptionContext): Promise<NextFrameContext> {
     const allStoreResults = await Promise.all(this.artstores.map((artstore) => {
       if (!artstore.getDetectableImages) {
         return [];
       }
       return artstore.getDetectableImages();
     }));
-    return flat(allStoreResults);
+    return { detectableImages: flat(allStoreResults) };
   }
 
   async perceive(context: PerceptionContext): Promise<PerceptionResultDelta> {

--- a/src/artifacts/artifact-dealer.ts
+++ b/src/artifacts/artifact-dealer.ts
@@ -41,6 +41,10 @@ export class ArtifactDealer {
   }
 
   async getPerceptionResults(context: PerceptionState): Promise<PerceptionResult[]> {
+    // Set default property values to empty lists, since they are optional.
+    // Do this because context may be passed to custom artstores (written in JS) which expect them defined.
+    context = Object.assign({ markers: [], geo: [], images: [] }, context);
+
     // Using current context (geo, markers), ask artstores to compute relevant artifacts
     const allStoreResults = await Promise.all(this.artstores.map((artstore) => {
       if (!artstore.findRelevantArtifacts) {

--- a/src/artifacts/artifact-dealer.ts
+++ b/src/artifacts/artifact-dealer.ts
@@ -15,29 +15,21 @@
  * limitations under the License.
  */
 
-import { DetectableImage, DetectedImage } from '../../defs/detected-image.js';
-import { Marker } from '../../defs/marker.js';
+import { DetectableImage } from '../../defs/detected-image.js';
 import { flat } from '../utils/flat.js';
-import { generateMarkerId } from '../utils/generate-marker-id.js';
-import { GeoCoordinates } from './schema/core-schema-org.js';
-import { ArtifactStore, NearbyResult } from './stores/artifact-store.js';
+import { ArtifactStore, PerceptionContext, PerceptionResult } from './stores/artifact-store.js';
 
-export { NearbyResult };
-export interface NearbyResultDelta {
-  found: NearbyResult[];
-  lost: NearbyResult[];
+export interface PerceptionResultDelta {
+  found: PerceptionResult[];
+  lost: PerceptionResult[];
 }
 
 export class ArtifactDealer {
   private readonly artstores: ArtifactStore[] = [];
-  private readonly nearbyMarkers = new Map<string, Marker>();
-  private readonly nearbyImages = new Map<string, DetectedImage>();
-  private nearbyResults = new Set<NearbyResult>();
-  private currentGeolocation: GeoCoordinates = {};
+  private prevPerceptionResults = new Set<PerceptionResult>();
 
-  async addArtifactStore(artstore: ArtifactStore): Promise<NearbyResultDelta> {
+  async addArtifactStore(artstore: ArtifactStore) {
     this.artstores.push(artstore);
-    return this.generateDiffs();
   }
 
   async getDetectableImages(): Promise<DetectableImage[]> {
@@ -50,59 +42,32 @@ export class ArtifactDealer {
     return flat(allStoreResults);
   }
 
-  async updateGeolocation(coords: GeoCoordinates): Promise<NearbyResultDelta> {
-    this.currentGeolocation = coords;
-    return this.generateDiffs();
-  }
-
-  async markerFound(marker: Marker): Promise<NearbyResultDelta> {
-    this.nearbyMarkers.set(generateMarkerId(marker.type, marker.value), marker);
-    return this.generateDiffs();
-  }
-
-  async markerLost(marker: Marker): Promise<NearbyResultDelta> {
-    this.nearbyMarkers.delete(generateMarkerId(marker.type, marker.value));
-    return this.generateDiffs();
-  }
-
-  async imageFound(detectedImage: DetectedImage): Promise<NearbyResultDelta> {
-    this.nearbyImages.set(detectedImage.id, detectedImage);
-    return this.generateDiffs();
-  }
-
-  async imageLost(detectedImage: DetectedImage): Promise<NearbyResultDelta> {
-    this.nearbyImages.delete(detectedImage.id);
-    return this.generateDiffs();
-  }
-
-  private async generateDiffs(): Promise<NearbyResultDelta> {
+  async perceive(context: PerceptionContext): Promise<PerceptionResultDelta> {
     // Using current context (geo, markers), ask artstores to compute relevant artifacts
     const allStoreResults = await Promise.all(this.artstores.map((artstore) => {
       if (!artstore.findRelevantArtifacts) {
         return [];
       }
-      return artstore.findRelevantArtifacts(
-        Array.from(this.nearbyMarkers.values()),
-        this.currentGeolocation,
-        Array.from(this.nearbyImages.values())
-      );
+      return artstore.findRelevantArtifacts(context);
     }));
-    const uniqueNearbyResults: Set<NearbyResult> = new Set(flat(allStoreResults));
+    const uniqueNearbyResults: Set<PerceptionResult> = new Set(flat(allStoreResults));
 
     // Diff with previous list to compute new/old artifacts.
     //  - New ones are those which haven't appeared before.
     //  - Old ones are those which are no longer nearby.
     //  - The remainder (intersection) are not reported.
-    const newNearbyResults: NearbyResult[] = [...uniqueNearbyResults].filter(a => !this.nearbyResults.has(a));
-    const oldNearbyresults: NearbyResult[] = [...this.nearbyResults].filter(a => !uniqueNearbyResults.has(a));
+    const newNearbyResults: PerceptionResult[] =
+        [...uniqueNearbyResults].filter(a => !this.prevPerceptionResults.has(a));
+    const oldNearbyresults: PerceptionResult[] =
+        [...this.prevPerceptionResults].filter(a => !uniqueNearbyResults.has(a));
 
-    const ret: NearbyResultDelta = {
+    const ret: PerceptionResultDelta = {
       found: [...newNearbyResults],
       lost: [...oldNearbyresults]
     };
 
     // Update current set of nearbyResults.
-    this.nearbyResults = uniqueNearbyResults;
+    this.prevPerceptionResults = uniqueNearbyResults;
 
     return ret;
   }

--- a/src/artifacts/artifact-dealer_test.ts
+++ b/src/artifacts/artifact-dealer_test.ts
@@ -147,6 +147,10 @@ describe('ArtifactDealer', () => {
       arContent: ''
     });
 
+    const predicted = await artDealer.predictPerceptionTargets({});
+    assert.isArray(predicted.detectableImages);
+    assert.lengthOf(predicted.detectableImages, 4);
+
     const result = await artDealer.getPerceptionResults({
       markers: [
         { type: 'qrcode', value: 'Barcode1' },
@@ -164,6 +168,10 @@ describe('ArtifactDealer', () => {
   it('Unimplemented stores are ignored', async () => {
     const otherStore = {} as ArtifactStore;
     artDealer.addArtifactStore(otherStore);
+
+    const predicted = await artDealer.predictPerceptionTargets({});
+    assert.isArray(predicted.detectableImages);
+    assert.lengthOf(predicted.detectableImages, 3);
 
     const result = await artDealer.getPerceptionResults({
       markers: [

--- a/src/artifacts/artifact-dealer_test.ts
+++ b/src/artifacts/artifact-dealer_test.ts
@@ -91,82 +91,45 @@ describe('ArtifactDealer', () => {
     });
 
     it('Ignores unknown markers', async () => {
-      const result = await artDealer.updatePerceptionState({
+      const result = await artDealer.getPerceptionResults({
         markers: [{
           type: 'qrcode',
           value: 'Unknown Marker'
         }]
       });
-      assert.isArray(result.found);
-      assert.isEmpty(result.found);
-      assert.isArray(result.lost);
-      assert.isEmpty(result.lost);
+      assert.isArray(result);
+      assert.isEmpty(result);
     });
 
     it('Finds known barcodes', async () => {
       const markers = [];
-      for (const value of ['Barcode1', 'Barcode2', 'Barcode3', 'Barcode4', 'Barcode5']) {
+      await Promise.all(['Barcode1', 'Barcode2', 'Barcode3', 'Barcode4', 'Barcode5'].map(async (value, i) => {
         markers.push({
           type: 'qrcode',
           value
         });
-        const result = await artDealer.updatePerceptionState({ markers });
-        assert.isArray(result.found);
-        assert.lengthOf(result.found, 1);
-        assert.equal((result.found[0].target as Barcode).text, value);
-
-        assert.isArray(result.lost);
-        assert.isEmpty(result.lost);
-      }
+        const result = await artDealer.getPerceptionResults({ markers: Array.from(markers) });
+        assert.isArray(result);
+        assert.lengthOf(result, i + 1);
+        assert.equal((result[i].target as Barcode).text, value);
+      }));
     });
 
     it('Finds known images', async () => {
       const images = [];
-      for (const id of ['Id1', 'Id2', 'Id3']) {
+      await Promise.all(['Id1', 'Id2', 'Id3'].map(async (id, i) => {
         images.push({ id });
-        const result = await artDealer.updatePerceptionState({ images });
-        assert.isArray(result.found);
-        assert.lengthOf(result.found, 1);
-        assert.equal((result.found[0].target as ARImageTarget).name, id);
-
-        assert.isArray(result.lost);
-        assert.isEmpty(result.lost);
-      }
-    });
-
-    it('Loses known markers', async () => {
-      await artDealer.updatePerceptionState({
-        markers: [{
-          type: 'qrcode',
-          value: 'Barcode1'
-        }]
-      });
-      const result = await artDealer.updatePerceptionState({});
-      assert.isArray(result.found);
-      assert.isEmpty(result.found);
-
-      assert.isArray(result.lost);
-      assert.lengthOf(result.lost, 1);
-      assert.equal((result.lost[0].target as Barcode).text, 'Barcode1');
-    });
-
-    it('Loses known images', async () => {
-      await artDealer.updatePerceptionState({ images: [ { id: 'Id1' } ] });
-      const result = await artDealer.updatePerceptionState({});
-      assert.isArray(result.found);
-      assert.isEmpty(result.found);
-
-      assert.isArray(result.lost);
-      assert.lengthOf(result.lost, 1);
-      assert.equal((result.lost[0].target as ARImageTarget).name, 'Id1');
+        const result = await artDealer.getPerceptionResults({ images: Array.from(images) });
+        assert.isArray(result);
+        assert.lengthOf(result, i + 1);
+        assert.equal((result[i].target as ARImageTarget).name, id);
+      }));
     });
 
     it('Ignores geolocation', async () => {
-      const result = await artDealer.updatePerceptionState({ geo: {} });
-      assert.isArray(result.found);
-      assert.isEmpty(result.found);
-      assert.isArray(result.lost);
-      assert.isEmpty(result.lost);
+      const result = await artDealer.getPerceptionResults({ geo: {} });
+      assert.isArray(result);
+      assert.isEmpty(result);
     });
   });
 
@@ -186,25 +149,25 @@ describe('ArtifactDealer', () => {
         arContent: 'Fake URL'
       });
 
-      const result1 = await artDealer.updatePerceptionState({
+      const result1 = await artDealer.getPerceptionResults({
         markers: [{
           type: 'qrcode',
           value: 'Barcode1'
         }]
       });
-      assert.isArray(result1.found);
-      assert.lengthOf(result1.found, 1);
-      assert.equal((result1.found[0].target as Barcode).text, 'Barcode1');
+      assert.isArray(result1);
+      assert.lengthOf(result1, 1);
+      assert.equal((result1[0].target as Barcode).text, 'Barcode1');
 
-      const result2 = await artDealer.updatePerceptionState({
+      const result2 = await artDealer.getPerceptionResults({
         markers: [{
           type: 'qrcode',
           value: 'Barcode2'
         }]
       });
-      assert.isArray(result2.found);
-      assert.lengthOf(result2.found, 1);
-      assert.equal((result2.found[0].target as Barcode).text, 'Barcode2');
+      assert.isArray(result2);
+      assert.lengthOf(result2, 1);
+      assert.equal((result2[0].target as Barcode).text, 'Barcode2');
     });
   });
 });

--- a/src/artifacts/artifact-dealer_test.ts
+++ b/src/artifacts/artifact-dealer_test.ts
@@ -91,9 +91,11 @@ describe('ArtifactDealer', () => {
     });
 
     it('Ignores unknown markers', async () => {
-      const result = await artDealer.markerFound({
-        type: 'qrcode',
-        value: 'Unknown Marker'
+      const result = await artDealer.updatePerceptionState({
+        markers: [{
+          type: 'qrcode',
+          value: 'Unknown Marker'
+        }]
       });
       assert.isArray(result.found);
       assert.isEmpty(result.found);
@@ -102,11 +104,13 @@ describe('ArtifactDealer', () => {
     });
 
     it('Finds known barcodes', async () => {
+      const markers = [];
       for (const value of ['Barcode1', 'Barcode2', 'Barcode3', 'Barcode4', 'Barcode5']) {
-        const result = await artDealer.markerFound({
+        markers.push({
           type: 'qrcode',
           value
         });
+        const result = await artDealer.updatePerceptionState({ markers });
         assert.isArray(result.found);
         assert.lengthOf(result.found, 1);
         assert.equal((result.found[0].target as Barcode).text, value);
@@ -117,8 +121,10 @@ describe('ArtifactDealer', () => {
     });
 
     it('Finds known images', async () => {
+      const images = [];
       for (const id of ['Id1', 'Id2', 'Id3']) {
-        const result = await artDealer.imageFound({ id });
+        images.push({ id });
+        const result = await artDealer.updatePerceptionState({ images });
         assert.isArray(result.found);
         assert.lengthOf(result.found, 1);
         assert.equal((result.found[0].target as ARImageTarget).name, id);
@@ -129,14 +135,13 @@ describe('ArtifactDealer', () => {
     });
 
     it('Loses known markers', async () => {
-      await artDealer.markerFound({
-        type: 'qrcode',
-        value: 'Barcode1'
+      await artDealer.updatePerceptionState({
+        markers: [{
+          type: 'qrcode',
+          value: 'Barcode1'
+        }]
       });
-      const result = await artDealer.markerLost({
-        type: 'qrcode',
-        value: 'Barcode1'
-      });
+      const result = await artDealer.updatePerceptionState({});
       assert.isArray(result.found);
       assert.isEmpty(result.found);
 
@@ -146,8 +151,8 @@ describe('ArtifactDealer', () => {
     });
 
     it('Loses known images', async () => {
-      await artDealer.imageFound({ id: 'Id1' });
-      const result = await artDealer.imageLost({ id: 'Id1' });
+      await artDealer.updatePerceptionState({ images: [ { id: 'Id1' } ] });
+      const result = await artDealer.updatePerceptionState({});
       assert.isArray(result.found);
       assert.isEmpty(result.found);
 
@@ -157,7 +162,7 @@ describe('ArtifactDealer', () => {
     });
 
     it('Ignores geolocation', async () => {
-      const result = await artDealer.updateGeolocation({});
+      const result = await artDealer.updatePerceptionState({ geo: {} });
       assert.isArray(result.found);
       assert.isEmpty(result.found);
       assert.isArray(result.lost);
@@ -181,27 +186,25 @@ describe('ArtifactDealer', () => {
         arContent: 'Fake URL'
       });
 
-      const result1 = await artDealer.markerFound({
-        type: 'qrcode',
-        value: 'Barcode1'
+      const result1 = await artDealer.updatePerceptionState({
+        markers: [{
+          type: 'qrcode',
+          value: 'Barcode1'
+        }]
       });
       assert.isArray(result1.found);
       assert.lengthOf(result1.found, 1);
       assert.equal((result1.found[0].target as Barcode).text, 'Barcode1');
 
-      assert.isArray(result1.lost);
-      assert.isEmpty(result1.lost);
-
-      const result2 = await artDealer.markerFound({
-        type: 'qrcode',
-        value: 'Barcode2'
+      const result2 = await artDealer.updatePerceptionState({
+        markers: [{
+          type: 'qrcode',
+          value: 'Barcode2'
+        }]
       });
       assert.isArray(result2.found);
       assert.lengthOf(result2.found, 1);
       assert.equal((result2.found[0].target as Barcode).text, 'Barcode2');
-
-      assert.isArray(result2.lost);
-      assert.isEmpty(result2.lost);
     });
   });
 });

--- a/src/artifacts/artifact-dealer_test.ts
+++ b/src/artifacts/artifact-dealer_test.ts
@@ -165,7 +165,7 @@ describe('ArtifactDealer', () => {
     assert.lengthOf(result, 4);
   });
 
-  it('Unimplemented stores are ignored', async () => {
+  it('unimplemented stores are ignored', async () => {
     const otherStore = {} as ArtifactStore;
     artDealer.addArtifactStore(otherStore);
 

--- a/src/artifacts/artifact-loader.ts
+++ b/src/artifacts/artifact-loader.ts
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
+import { flat } from '../utils/flat.js';
 import { ArtifactDecoder } from './artifact-decoder.js';
 import { ARArtifact } from './schema/extension-ar-artifacts.js';
 import { JsonLd } from './schema/json-ld.js';
-import { flat } from '../utils/flat.js';
 
 // TODO: Consider merging from*Url functions and just branching on response content-type
 export class ArtifactLoader {

--- a/src/artifacts/stores/artifact-store.ts
+++ b/src/artifacts/stores/artifact-store.ts
@@ -38,6 +38,6 @@ export interface PerceptionResult {
 }
 
 export interface ArtifactStore {
-  getDetectableImages?(): Promise<DetectableImage[]>;
+  getDetectableImages?(state: PerceptionState): Promise<DetectableImage[]>;
   findRelevantArtifacts?(state: PerceptionState): Promise<PerceptionResult[]>;
 }

--- a/src/artifacts/stores/artifact-store.ts
+++ b/src/artifacts/stores/artifact-store.ts
@@ -21,18 +21,23 @@ import { GeoCoordinates } from '../schema/core-schema-org.js';
 import { ARArtifact, ARTargetTypes } from '../schema/extension-ar-artifacts.js';
 
 /*
- * NearbyResult combines for an ARArtifact result, and the specific ARTargetType that was used to trigger it.
+ * PerceptionContext is usually created per-captured video frame, and encodes the most up to date context.
  */
-export interface NearbyResult {
-  target?: ARTargetTypes;
+export interface PerceptionContext {
+  markers: Marker[];
+  geo: GeoCoordinates;
+  images: DetectedImage[];
+}
+
+/*
+ * PerceptionResult combines an ARArtifact result, and the specific ARTargetType that was used to trigger it.
+ */
+export interface PerceptionResult {
   artifact: ARArtifact;
+  trigger?: ARTargetTypes;
 }
 
 export interface ArtifactStore {
   getDetectableImages?(): Promise<DetectableImage[]>;
-  findRelevantArtifacts?(
-      nearbyMarkers: Marker[],
-      geo: GeoCoordinates,
-      detectedImages: DetectedImage[]
-    ): Promise<NearbyResult[]>;
+  findRelevantArtifacts?(context: PerceptionContext): Promise<PerceptionResult[]>;
 }

--- a/src/artifacts/stores/artifact-store.ts
+++ b/src/artifacts/stores/artifact-store.ts
@@ -23,21 +23,21 @@ import { ARArtifact, ARTargetTypes } from '../schema/extension-ar-artifacts.js';
 /*
  * PerceptionContext is usually created per-captured video frame, and encodes the most up to date context.
  */
-export interface PerceptionContext {
-  markers: Marker[];
-  geo: GeoCoordinates;
-  images: DetectedImage[];
+export interface PerceptionState {
+  markers?: Marker[];
+  geo?: GeoCoordinates;
+  images?: DetectedImage[];
 }
 
 /*
  * PerceptionResult combines an ARArtifact result, and the specific ARTargetType that was used to trigger it.
  */
 export interface PerceptionResult {
+  target?: ARTargetTypes;
   artifact: ARArtifact;
-  trigger?: ARTargetTypes;
 }
 
 export interface ArtifactStore {
   getDetectableImages?(): Promise<DetectableImage[]>;
-  findRelevantArtifacts?(context: PerceptionContext): Promise<PerceptionResult[]>;
+  findRelevantArtifacts?(state: PerceptionState): Promise<PerceptionResult[]>;
 }

--- a/src/artifacts/stores/artifact-store.ts
+++ b/src/artifacts/stores/artifact-store.ts
@@ -21,7 +21,7 @@ import { GeoCoordinates } from '../schema/core-schema-org.js';
 import { ARArtifact, ARTargetTypes } from '../schema/extension-ar-artifacts.js';
 
 /*
- * PerceptionContext is usually created per-captured video frame, and encodes the most up to date context.
+ * PerceptionState is usually created per-captured video frame, and includes all the currently detected targets.
  */
 export interface PerceptionState {
   markers?: Marker[];
@@ -30,7 +30,7 @@ export interface PerceptionState {
 }
 
 /*
- * PerceptionResult combines an ARArtifact result, and the specific ARTargetType that was used to trigger it.
+ * PerceptionResult combines an ARArtifact result, with the specific ARTargetType that was used to trigger it.
  */
 export interface PerceptionResult {
   target?: ARTargetTypes;

--- a/src/artifacts/stores/local-artifact-store.ts
+++ b/src/artifacts/stores/local-artifact-store.ts
@@ -16,11 +16,9 @@
  */
 
 import { DetectableImage, DetectedImage } from '../../../defs/detected-image.js';
-import { Marker } from '../../../defs/marker.js';
-import { NearbyResult } from '../artifact-dealer.js';
-import { Barcode, GeoCoordinates, Thing, typeIsThing } from '../schema/core-schema-org.js';
-import { ARArtifact, ARImageTarget, ARTargetTypes } from '../schema/extension-ar-artifacts.js';
-import { ArtifactStore } from './artifact-store.js';
+import { typeIsThing } from '../schema/core-schema-org.js';
+import { ARArtifact, ARTargetTypes } from '../schema/extension-ar-artifacts.js';
+import { ArtifactStore, PerceptionContext, PerceptionResult } from './artifact-store.js';
 import { LocalImageStore } from './local-image-store.js';
 import { LocalMarkerStore } from './local-marker-store.js';
 
@@ -65,11 +63,10 @@ export class LocalArtifactStore implements ArtifactStore {
     return totalAdded;
   }
 
-  async findRelevantArtifacts(nearbyMarkers: Marker[], geo: GeoCoordinates, detectedImages: DetectedImage[]
-      ): Promise<NearbyResult[]> {
+  async findRelevantArtifacts?(context: PerceptionContext): Promise<PerceptionResult[]> {
     return [
-      ...this.markerStore.findRelevantArtifacts(nearbyMarkers),
-      ...this.imageStore.findRelevantArtifacts(detectedImages),
+      ...this.markerStore.findRelevantArtifacts(context.markers),
+      ...this.imageStore.findRelevantArtifacts(context.images),
     ];
   }
 

--- a/src/artifacts/stores/local-artifact-store.ts
+++ b/src/artifacts/stores/local-artifact-store.ts
@@ -18,7 +18,7 @@
 import { DetectableImage, DetectedImage } from '../../../defs/detected-image.js';
 import { typeIsThing } from '../schema/core-schema-org.js';
 import { ARArtifact, ARTargetTypes } from '../schema/extension-ar-artifacts.js';
-import { ArtifactStore, PerceptionContext, PerceptionResult } from './artifact-store.js';
+import { ArtifactStore, PerceptionResult, PerceptionState } from './artifact-store.js';
 import { LocalImageStore } from './local-image-store.js';
 import { LocalMarkerStore } from './local-marker-store.js';
 
@@ -63,10 +63,10 @@ export class LocalArtifactStore implements ArtifactStore {
     return totalAdded;
   }
 
-  async findRelevantArtifacts?(context: PerceptionContext): Promise<PerceptionResult[]> {
+  async findRelevantArtifacts?(state: PerceptionState): Promise<PerceptionResult[]> {
     return [
-      ...this.markerStore.findRelevantArtifacts(context.markers),
-      ...this.imageStore.findRelevantArtifacts(context.images),
+      ...this.markerStore.findRelevantArtifacts(state.markers || []),
+      ...this.imageStore.findRelevantArtifacts(state.images || []),
     ];
   }
 

--- a/src/artifacts/stores/local-artifact-store.ts
+++ b/src/artifacts/stores/local-artifact-store.ts
@@ -70,7 +70,7 @@ export class LocalArtifactStore implements ArtifactStore {
     ];
   }
 
-  async getDetectableImages(): Promise<DetectableImage[]> {
+  async getDetectableImages(state: PerceptionState): Promise<DetectableImage[]> {
     return this.imageStore.getDetectableImages();
   }
 }

--- a/src/artifacts/stores/local-artifact-store_test.ts
+++ b/src/artifacts/stores/local-artifact-store_test.ts
@@ -106,19 +106,34 @@ describe('LocalArtifactStore', () => {
     });
 
     it('finds barcodes', async () => {
-      const results = await localArtifactStore.findRelevantArtifacts(
-        [{ type: 'qrcode', value: 'Barcode Value' }], {}, []);
+      const results = await localArtifactStore.findRelevantArtifacts({
+        markers: [{
+          type: 'qrcode',
+          value: 'Barcode Value'
+        }]
+      });
       assert.lengthOf(results, 1);
     });
 
     it('finds images', async () => {
-      const results = await localArtifactStore.findRelevantArtifacts([], {}, [ { id: 'ID1' } ]);
+      const results = await localArtifactStore.findRelevantArtifacts({
+        images: [{
+          id: 'ID1'
+        }]
+      });
       assert.lengthOf(results, 1);
     });
 
     it('can find both barcodes and images at once', async () => {
-      const results = await localArtifactStore.findRelevantArtifacts(
-        [{ type: 'qrcode', value: 'Barcode Value' }], {}, [{ id: 'ID1' }]);
+      const results = await localArtifactStore.findRelevantArtifacts({
+        markers: [{
+          type: 'qrcode',
+          value: 'Barcode Value'
+        }],
+        images: [{
+          id: 'ID1'
+        }]
+      });
       assert.lengthOf(results, 2);
     });
   });

--- a/src/artifacts/stores/local-artifact-store_test.ts
+++ b/src/artifacts/stores/local-artifact-store_test.ts
@@ -50,7 +50,7 @@ describe('LocalArtifactStore', () => {
       const totalAdded = localArtifactStore.addArtifact(artifact);
       assert.equal(totalAdded, 1);
 
-      const detectableImages = await localArtifactStore.getDetectableImages();
+      const detectableImages = await localArtifactStore.getDetectableImages({});
       assert.isArray(detectableImages);
       assert.lengthOf(detectableImages, 1);
     });

--- a/src/artifacts/stores/local-image-store.ts
+++ b/src/artifacts/stores/local-image-store.ts
@@ -28,14 +28,14 @@ export class LocalImageStore {
       return false;
     }
 
-    this.images.set(imageTarget.name, { trigger: imageTarget, artifact });
+    this.images.set(imageTarget.name, { target: imageTarget, artifact });
     return true;
   }
 
   getDetectableImages(): DetectableImage[] {
     const allDetectableImages: DetectableImage[] = [];
 
-    for (const { trigger: target } of this.images.values()) {
+    for (const { target: target } of this.images.values()) {
       if (!typeIsThing(target) || target['@type'] !== 'ARImageTarget' || !target.name) {
         continue;
       }

--- a/src/artifacts/stores/local-image-store.ts
+++ b/src/artifacts/stores/local-image-store.ts
@@ -35,7 +35,7 @@ export class LocalImageStore {
   getDetectableImages(): DetectableImage[] {
     const allDetectableImages: DetectableImage[] = [];
 
-    for (const { target: target } of this.images.values()) {
+    for (const { target } of this.images.values()) {
       if (!typeIsThing(target) || target['@type'] !== 'ARImageTarget' || !target.name) {
         continue;
       }

--- a/src/artifacts/stores/local-image-store.ts
+++ b/src/artifacts/stores/local-image-store.ts
@@ -16,27 +16,26 @@
  */
 
 import { DetectableImage, DetectedImage } from '../../../defs/detected-image.js';
-import { NearbyResult } from '../artifact-dealer.js';
-import { ARArtifact, ARImageTarget } from '../schema/extension-ar-artifacts.js';
-import { typeIsJsonLd } from '../schema/json-ld.js';
 import { typeIsThing } from '../schema/core-schema-org.js';
+import { ARArtifact, ARImageTarget } from '../schema/extension-ar-artifacts.js';
+import { PerceptionResult } from './artifact-store.js';
 
 export class LocalImageStore {
-  private readonly images = new Map<string, NearbyResult>();
+  private readonly images = new Map<string, PerceptionResult>();
 
   addImage(artifact: ARArtifact, imageTarget: ARImageTarget): boolean {
     if (!imageTarget.name) {
       return false;
     }
 
-    this.images.set(imageTarget.name, { target: imageTarget, artifact });
+    this.images.set(imageTarget.name, { trigger: imageTarget, artifact });
     return true;
   }
 
   getDetectableImages(): DetectableImage[] {
     const allDetectableImages: DetectableImage[] = [];
 
-    for (const { target } of this.images.values()) {
+    for (const { trigger: target } of this.images.values()) {
       if (!typeIsThing(target) || target['@type'] !== 'ARImageTarget' || !target.name) {
         continue;
       }
@@ -72,7 +71,7 @@ export class LocalImageStore {
     return allDetectableImages;
   }
 
-  findRelevantArtifacts(detectedImages: DetectedImage[]): NearbyResult[] {
+  findRelevantArtifacts(detectedImages: DetectedImage[]): PerceptionResult[] {
     const ret = [];
     for (const detectedImage of detectedImages) {
       const nearbyResult = this.images.get(detectedImage.id);

--- a/src/artifacts/stores/local-marker-store.ts
+++ b/src/artifacts/stores/local-marker-store.ts
@@ -16,22 +16,22 @@
  */
 
 import { Marker } from '../../../defs/marker.js';
-import { NearbyResult } from '../artifact-dealer.js';
-import { ARArtifact } from '../schema/extension-ar-artifacts.js';
 import { Barcode } from '../schema/core-schema-org.js';
+import { ARArtifact } from '../schema/extension-ar-artifacts.js';
+import { PerceptionResult } from './artifact-store.js';
 
 export class LocalMarkerStore {
-  private readonly markers = new Map<string, NearbyResult>();
+  private readonly markers = new Map<string, PerceptionResult>();
 
   addMarker(artifact: ARArtifact, barcode: Barcode): boolean {
     if (!barcode.text) {
       return false;
     }
-    this.markers.set(barcode.text, { target: barcode, artifact });
+    this.markers.set(barcode.text, { trigger: barcode, artifact });
     return true;
   }
 
-  findRelevantArtifacts(markers: Marker[]): NearbyResult[] {
+  findRelevantArtifacts(markers: Marker[]): PerceptionResult[] {
     const ret = [];
     for (const marker of markers) {
       const nearbyResult = this.markers.get(marker.value);

--- a/src/artifacts/stores/local-marker-store.ts
+++ b/src/artifacts/stores/local-marker-store.ts
@@ -27,7 +27,7 @@ export class LocalMarkerStore {
     if (!barcode.text) {
       return false;
     }
-    this.markers.set(barcode.text, { trigger: barcode, artifact });
+    this.markers.set(barcode.text, { target: barcode, artifact });
     return true;
   }
 

--- a/src/detectors/planar-image/planar-image.ts
+++ b/src/detectors/planar-image/planar-image.ts
@@ -16,8 +16,7 @@
  * limitations under the License.
  */
 
-import { DetectableImage } from '../../../defs/detected-image.js';
-import { Marker } from '../../../defs/marker.js';
+import { DetectableImage, DetectedImage } from '../../../defs/detected-image.js';
 import { DEBUG_LEVEL, log } from '../../utils/logger.js';
 
 class Detector {
@@ -46,7 +45,7 @@ class Detector {
     return this.isReadyInternal;
   }
 
-  detect(data: ImageData): Promise<Marker[]> {
+  detect(data: ImageData): Promise<DetectedImage[]> {
     if (this.targets.size === 0) {
       return Promise.resolve([]);
     }
@@ -62,21 +61,11 @@ class Detector {
 
         const matches = e.data as number[];
 
-        // Remap to actual target values and filter out empties.
-        const ids = matches.map((id) => {
-          const target = this.targets.get(id);
-          /* istanbul ignore if */
-          if (!target) {
-            return { value: null };
-          }
+        // Remap to actual DetectedImage targets (and filter out empties).
+        const detectedImages = matches.map((id) => this.targets.get(id))
+            .filter(detectedImage => !!detectedImage) as DetectedImage[];
 
-          return {
-            type: 'ARImageTarget',
-            value: target.id,
-          };
-        }).filter(value => !!value.value) as Marker[];
-
-        resolve(ids);
+        resolve(detectedImages);
         log(`Time taken (ms): ${performance.now() - startTime} ` +
             `for ${data.width} * ${data.height}`, DEBUG_LEVEL.VERBOSE);
       };

--- a/src/detectors/planar-image/planar-image_test.ts
+++ b/src/detectors/planar-image/planar-image_test.ts
@@ -58,7 +58,7 @@ describe('Planar Image Detector', () => {
 
     const detections = await detectPlanarImages(await imageData, { root: '/base' });
     assert.equal(detections.length, 1);
-    assert.equal(detections[0].value, 'Lighthouse');
+    assert.equal(detections[0].id, 'Lighthouse');
     await removeDetectionTarget(id);
 
     const postRemovalDetections = await detectPlanarImages(await imageData, { root: '/base' });

--- a/src/elements/meaning-maker/meaning-maker.ts
+++ b/src/elements/meaning-maker/meaning-maker.ts
@@ -174,9 +174,9 @@ export class MeaningMaker {
 
     // Perception state includes all the markers/images we have seen recently.
     const state: PerceptionState = {
-      markers: Array.from(this.lastSeenMarkers.keys()).map((markerJson) => JSON.parse(markerJson) as Marker),
+      markers: Array.from(this.lastSeenMarkers.values(), ({ marker }) => marker),
       geo: request.geo,
-      images: Array.from(this.lastSeenImages.keys()).map((imageJson) => JSON.parse(imageJson) as DetectedImage)
+      images: Array.from(this.lastSeenImages.values(), ({ image }) => image)
     };
 
     const nearbyResults = await this.artdealer.getPerceptionResults(state);

--- a/src/elements/meaning-maker/meaning-maker.ts
+++ b/src/elements/meaning-maker/meaning-maker.ts
@@ -107,6 +107,7 @@ export class MeaningMaker {
     if (this.artifactsForUrl.has(url.toString())) {
       return this.artifactsForUrl.get(url.toString()) as ARArtifact[];
     }
+
     const artifacts = await this.artloader.fromUrl(url);
     this.saveArtifacts(artifacts);
     this.artifactsForUrl.set(url.toString(), artifacts);

--- a/src/elements/meaning-maker/meaning-maker_test.ts
+++ b/src/elements/meaning-maker/meaning-maker_test.ts
@@ -31,12 +31,18 @@ describe('Meaning Maker', () => {
 
     const url = new URL('/base/test-assets/test1.html', window.location.href);
     const artifacts = await meaningMaker.loadArtifactsFromUrl(url);
-    assert.equal(artifacts.length, 1);
+    assert.lengthOf(artifacts, 1);
   });
 
   it('handles bad loads from URLs', async () => {
     const meaningMaker = await initMM();
-    await meaningMaker.loadArtifactsFromUrl(new URL('bad-url.html', window.location.href));
+    try {
+      await meaningMaker.loadArtifactsFromUrl(new URL('bad-url.html', window.location.href));
+    } catch (err) {
+      // This is a workaround sync assert.throws() doesn't handle async yet.
+      // See: https://github.com/chaijs/chai/issues/415
+      assert.throws(() => { throw err; });
+    }
   });
 
   it('loads from supported origins', async () => {
@@ -47,7 +53,7 @@ describe('Meaning Maker', () => {
         await meaningMaker.loadArtifactsFromSupportedUrl(url, (url: URL) => {
           return url.origin === window.origin;
         });
-    assert.equal(artifacts.length, 1);
+    assert.lengthOf(artifacts, 1);
   });
 
   it('loads from same-origin if unspecified', async () => {
@@ -55,7 +61,7 @@ describe('Meaning Maker', () => {
 
     const url = new URL('/base/test-assets/test1.html', window.location.href);
     const artifacts = await meaningMaker.loadArtifactsFromSupportedUrl(url);
-    assert.equal(artifacts.length, 1);
+    assert.lengthOf(artifacts, 1);
   });
 
   it('ignores unsupported origins', async () => {
@@ -66,7 +72,7 @@ describe('Meaning Maker', () => {
         await meaningMaker.loadArtifactsFromSupportedUrl(url, (url: URL) => {
           return false;
         });
-    assert.equal(artifacts.length, 0);
+    assert.lengthOf(artifacts, 0);
   });
 
   it('supports origins as strings', async () => {
@@ -75,7 +81,7 @@ describe('Meaning Maker', () => {
     const url = new URL('/base/test-assets/test1.html', window.location.href);
     const artifacts = await meaningMaker.loadArtifactsFromSupportedUrl(url,
       [window.location.origin]);
-    assert.equal(artifacts.length, 1);
+    assert.lengthOf(artifacts, 1);
   });
 
   it('returns all Image Targets as detectableImages', async () => {
@@ -84,8 +90,8 @@ describe('Meaning Maker', () => {
     const url = new URL('/base/test-assets/test-image.html', window.location.href);
     const artifacts = await meaningMaker.loadArtifactsFromSupportedUrl(url);
     const images = (await meaningMaker.updatePerceptionState({})).detectableImages;
-    assert.equal(artifacts.length, 1, 'No artifacts');
-    assert.equal(images.length, 1, 'No image artifacts');
+    assert.lengthOf(artifacts, 1, 'No artifacts');
+    assert.lengthOf(images, 1, 'No image artifacts');
   });
 
   it('finds and loses markers', async () => {
@@ -100,12 +106,12 @@ describe('Meaning Maker', () => {
 
     const foundResponse = await meaningMaker.updatePerceptionState({ markers: [ marker ] });
     assert.isDefined(foundResponse);
-    assert.equal(foundResponse.found.length, 1);
-    assert.equal(foundResponse.lost.length, 0);
+    assert.lengthOf(foundResponse.found, 1);
+    assert.lengthOf(foundResponse.lost, 0);
 
     const lostResponse = await meaningMaker.updatePerceptionState({});
-    assert.equal(lostResponse.found.length, 0);
-    assert.equal(lostResponse.lost.length, 1);
+    assert.lengthOf(lostResponse.found, 0);
+    assert.lengthOf(lostResponse.lost, 1);
   });
 
   it('finds and loses images', async () => {
@@ -119,12 +125,12 @@ describe('Meaning Maker', () => {
 
     const foundResponse = await meaningMaker.updatePerceptionState({ images: [ detectedImage ] });
     assert.isDefined(foundResponse);
-    assert.equal(foundResponse.found.length, 1);
-    assert.equal(foundResponse.lost.length, 0);
+    assert.lengthOf(foundResponse.found, 1);
+    assert.lengthOf(foundResponse.lost, 0);
 
     const lostResponse = await meaningMaker.updatePerceptionState({});
-    assert.equal(lostResponse.found.length, 0);
-    assert.equal(lostResponse.lost.length, 1);
+    assert.lengthOf(lostResponse.found, 0);
+    assert.lengthOf(lostResponse.lost, 1);
   });
 
   it('accepts updated locations without any geofenced artifacts', async () => {
@@ -145,13 +151,13 @@ describe('Meaning Maker', () => {
     // Add the marker.
     const foundResponse = await meaningMaker.updatePerceptionState({ markers: [ marker ] });
     assert.isDefined(foundResponse);
-    assert.equal(foundResponse.found.length, 1);
-    assert.equal(foundResponse.lost.length, 0);
+    assert.lengthOf(foundResponse.found, 1);
+    assert.lengthOf(foundResponse.lost, 0);
 
     // Add the marker, alongside geo change
     const locationResponse = await meaningMaker.updatePerceptionState({ markers: [ marker ], geo });
     assert.isDefined(locationResponse);
-    assert.equal(locationResponse.found.length, 0);
-    assert.equal(locationResponse.lost.length, 0);
+    assert.lengthOf(locationResponse.found, 0);
+    assert.lengthOf(locationResponse.lost, 0);
   });
 });

--- a/src/elements/meaning-maker/meaning-maker_test.ts
+++ b/src/elements/meaning-maker/meaning-maker_test.ts
@@ -22,6 +22,7 @@ import { MeaningMaker } from './meaning-maker.js';
 async function initMM() {
   const meaningMaker = new MeaningMaker();
   await meaningMaker.init();
+  meaningMaker.lastSeenTimeBuffer = 0;
   return meaningMaker;
 }
 

--- a/src/elements/perception-toolkit/perception-toolkit.ts
+++ b/src/elements/perception-toolkit/perception-toolkit.ts
@@ -90,7 +90,7 @@ export class PerceptionToolkit extends HTMLElement {
   private readonly onMarkerFoundBound = this.onMarkerFound.bind(this);
   private readonly onCaptureFrameBound = this.onCaptureFrame.bind(this);
   private readonly onCloseBound = this.onClose.bind(this);
-  private readonly startupDetections: Array<Promise<object[]>> = [];
+  private readonly startupDetections: Array<Promise<Array<{}>>> = [];
   private readonly detectorsToUse = {
     barcode: true,
     image: false
@@ -499,8 +499,7 @@ export class PerceptionToolkit extends HTMLElement {
 
   private handleUnknownItems(targets: Marker[]) {
     if (!cardContainer ||  // No card container.
-        !acknowledgeUnknownItems // The config says to ignore unknowns.
-    ) {
+        !acknowledgeUnknownItems) {// The config says to ignore unknowns.
       return;
     }
 

--- a/src/elements/perception-toolkit/perception-toolkit.ts
+++ b/src/elements/perception-toolkit/perception-toolkit.ts
@@ -90,7 +90,7 @@ export class PerceptionToolkit extends HTMLElement {
   private readonly onMarkerFoundBound = this.onMarkerFound.bind(this);
   private readonly onCaptureFrameBound = this.onCaptureFrame.bind(this);
   private readonly onCloseBound = this.onClose.bind(this);
-  private readonly startupDetections: Array<Promise<any[]>> = [];
+  private readonly startupDetections: Array<Promise<object[]>> = [];
   private readonly detectorsToUse = {
     barcode: true,
     image: false

--- a/src/elements/perception-toolkit/perception-toolkit.ts
+++ b/src/elements/perception-toolkit/perception-toolkit.ts
@@ -271,7 +271,7 @@ export class PerceptionToolkit extends HTMLElement {
       hideOverlay(overlayInit);
 
       // TODO: This sets up MM initial context.  May want to change how this works.
-      const nextFrameContext = await this.meaningMaker.perceive({
+      const nextFrameContext = await this.meaningMaker.updatePerceptionState({
         markers: [],
         geo: {},
         images: []
@@ -454,7 +454,7 @@ export class PerceptionToolkit extends HTMLElement {
     }
     */
 
-    const response = await this.meaningMaker.perceive({
+    const response = await this.meaningMaker.updatePerceptionState({
       markers: detectedMarkers,
       geo: {},
       images: detectedImages,

--- a/src/elements/perception-toolkit/perception-toolkit.ts
+++ b/src/elements/perception-toolkit/perception-toolkit.ts
@@ -423,8 +423,6 @@ export class PerceptionToolkit extends HTMLElement {
   }
 
   private async onCaptureFrame(evt: Event) {
-    console.log('captureAndEmit', performance.now(), this.isProcessingFrame);
-
     // Lock until the frame has been processed.
     if (this.isProcessingFrame) { 
       return;

--- a/src/utils/generate-marker-id.ts
+++ b/src/utils/generate-marker-id.ts
@@ -15,10 +15,12 @@
  * limitations under the License.
  */
 
+import { Marker } from '../../defs/marker';
+
 /**
  * Convert a marker type (barcode, qrcode, etc) and its value into a unique id
  *
  */
-export function generateMarkerId(type: string, value: string): string {
-  return type + '__' + value;
+export function generateMarkerId(marker: Marker): string {
+  return marker.type + '__' + marker.value;
 }

--- a/src/utils/generate-marker-id_test.ts
+++ b/src/utils/generate-marker-id_test.ts
@@ -21,7 +21,13 @@ import { generateMarkerId } from './generate-marker-id.js';
 
 describe('Generate Marker ID', () => {
   it('generates marker IDs', async () => {
-    const id = generateMarkerId('foo', 'bar');
+    const id = generateMarkerId({ type: 'foo', value: 'bar' });
     assert.equal(id, 'foo__bar');
+  });
+
+  it('different marker types have different ids', async () => {
+    const id1 = generateMarkerId({ type: 'barcode', value: 'bar' });
+    const id2 = generateMarkerId({ type: 'qr_code', value: 'bar' });
+    assert.notEqual(id1, id2);
   });
 });


### PR DESCRIPTION
I'm still doing some manual tests for this refactor, but the simple demo cases work for me, and the console logs seem to make sense.

Since this ended up being more beefy than expected, I wrote up a big picture summary (below).  If need be, I can break this up into cleaner parts, since I now know which parts where necessary for what.


Significant Changes:
- Bugfix: PT previously never fired events for "lost" content.  (`purgeOldMarkers` cleaned up but didn't fire)
- Refactor: MM replaces all Found/Lost calls with an `updatePerceptionState` call.
- Feature: MM now returns all `ProbableTargets` and does so every frame, instead of supplying just `detectableImages` and just on startup.
  - (ProbableTargets still just has images for now, but we can add any params needed for detectors.)
  - However, PT only calls `prepareForNextFrame` once on startup.  I didn't want to do per-frame until I ensure efficient image loading per-frame.  Future patch.
- Feature: MM now tracks URLs it indexed, so it won't index them again.  This also fixed a bug w/ dynamic URL markers leading to duplicate artifacts found (if that artifact was already indexed on startup via tests/config).
- Refactor: Moved "timeout" tracking from PT to MM.  That moved "new target" tracking to MM.  Events still fire from PT for now.
- Refactor: ArtifactDealer removed all state tracking since (it gets all context at once now), and so I moved "diff"  code up to MM (which does track state, for timeouts).
- Refactor: DetectedImages are no longer shoehorned into Markers (e.g. in PT, in planar image detector, and in MM).
  - this simplified a few code paths, and complicated others (e.g. now have similar/duplicate code in a few places).  Filed a bug for implementing a common base-class for these things, which is clean that up.
- Tests: Updated lots due to changes, but nothing significant.
- (Sorta?) Breaking Change: If multiple new markers are found in one frame, but we only partially get found results, we have at one unknown marker -- but don't know which one.  Today, we already don't put up a card for unknown marker if there is at least 1 content result, anyway, so this change is not visible.  But we should resolve the ambiguity (ideas below)
- Feature: create multiple unknown result cards if maxCards > 1


Questions:
- Dealing with lastSeenTimeBuffer in tests -- for now I just override to 0ms.  WDYT?  Should we fake the clock, mock out performance.now?

Future changes?
- call prepareForNextFrame every frame.
- Artdealer::getPerceptionResults to include the perception state used to lead to a specific result.
- Maybe change the way we track "new targets" by instead having MM return all: along found: and lost:.  Seems useful anyway, and this way we can infer whats new (once PerceptionResult includes original target alongside)
