### PR TITLE
Fix #135: replace flaky MM test for dynamic markers with simple barcode test

### DIFF
--- a/src/artifacts/artifact-loader.ts
+++ b/src/artifacts/artifact-loader.ts
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
+import { flat } from '../utils/flat.js';
 import { ArtifactDecoder } from './artifact-decoder.js';
 import { ARArtifact } from './schema/extension-ar-artifacts.js';
 import { JsonLd } from './schema/json-ld.js';
-import { flat } from '../utils/flat.js';
 
 // TODO: Consider merging from*Url functions and just branching on response content-type
 export class ArtifactLoader {
@@ -27,7 +27,7 @@ export class ArtifactLoader {
   async fromUrl(url: URL|string): Promise<ARArtifact[]> {
     const response = await fetch(url.toString());
     if (!response.ok) {
-        throw Error(response.statusText);
+        throw Error(`Fetch failure for ${url} with status: ${response.statusText}`);
     }
     const contentType = response.headers.get('content-type');
     if (!contentType) {
@@ -53,7 +53,7 @@ export class ArtifactLoader {
 
     const response = await fetch(url.toString());
     if (!response.ok) {
-        throw Error(response.statusText);
+        throw Error(`Fetch failure for ${url} with status: ${response.statusText}`);
     }
     const html = await response.text();
     const parser = new DOMParser();
@@ -64,13 +64,13 @@ export class ArtifactLoader {
   async fromJsonUrl(url: URL|string): Promise<ARArtifact[]> {
     const response = await fetch(url.toString());
     if (!response.ok) {
-        throw Error(response.statusText);
+        throw Error(`Fetch failure for ${url} with status: ${response.statusText}`);
     }
     const json = await response.json();
     return this.fromJson(json);
   }
 
-  async fromElement(el: NodeSelector, url: URL|string): Promise<ARArtifact[]> {
+  async fromElement(el: ParentNode, url: URL|string): Promise<ARArtifact[]> {
     const ret = [];
 
     const inlineScripts = el.querySelectorAll('script[type=\'application/ld+json\']:not([src])');

--- a/src/elements/meaning-maker/meaning-maker_test.ts
+++ b/src/elements/meaning-maker/meaning-maker_test.ts
@@ -29,7 +29,7 @@ describe('Meaning Maker', () => {
   it('loads from URLs', async () => {
     const meaningMaker = await initMM();
 
-    const url = new URL('/base/test-assets/test1.html', window.location.href);
+    const url = new URL('/base/test-assets/test-barcode.html', window.location.href);
     const artifacts = await meaningMaker.loadArtifactsFromUrl(url);
     assert.equal(artifacts.length, 1);
   });
@@ -45,7 +45,7 @@ describe('Meaning Maker', () => {
   it('loads from supported origins', async () => {
     const meaningMaker = await initMM();
 
-    const url = new URL('/base/test-assets/test1.html', window.location.href);
+    const url = new URL('/base/test-assets/test-barcode.html', window.location.href);
     const artifacts =
         await meaningMaker.loadArtifactsFromSupportedUrl(url, (url: URL) => {
           return url.origin === window.origin;
@@ -56,7 +56,7 @@ describe('Meaning Maker', () => {
   it('loads from same-origin if unspecified', async () => {
     const meaningMaker = await initMM();
 
-    const url = new URL('/base/test-assets/test1.html', window.location.href);
+    const url = new URL('/base/test-assets/test-barcode.html', window.location.href);
     const artifacts = await meaningMaker.loadArtifactsFromSupportedUrl(url);
     assert.equal(artifacts.length, 1);
   });
@@ -64,7 +64,7 @@ describe('Meaning Maker', () => {
   it('ignores unsupported origins', async () => {
     const meaningMaker = await initMM();
 
-    const url = new URL('/base/test-assets/test1.html', window.location.href);
+    const url = new URL('/base/test-assets/test-barcode.html', window.location.href);
     const artifacts =
         await meaningMaker.loadArtifactsFromSupportedUrl(url, (url: URL) => {
           return false;
@@ -75,7 +75,7 @@ describe('Meaning Maker', () => {
   it('supports origins as strings', async () => {
     const meaningMaker = await initMM();
 
-    const url = new URL('/base/test-assets/test1.html', window.location.href);
+    const url = new URL('/base/test-assets/test-barcode.html', window.location.href);
     const artifacts = await meaningMaker.loadArtifactsFromSupportedUrl(url,
       [window.location.origin]);
     assert.equal(artifacts.length, 1);
@@ -91,12 +91,15 @@ describe('Meaning Maker', () => {
     assert.equal(images.length, 1, 'No image artifacts');
   });
 
-  it('finds and loses markers', async () => {
+  it('finds and loses barcodes', async () => {
     const meaningMaker = await initMM();
-    const url = new URL('/base/test-assets/test1.html', window.location.href);
+    const url = new URL('/base/test-assets/test-barcode.html', window.location.href);
+    const artifacts = await meaningMaker.loadArtifactsFromUrl(url);
+    assert.lengthOf(artifacts, 1);
+
     const marker = {
       type: 'qr_code',
-      value: url.href
+      value: '1234567890'
     };
 
     const foundResponse = await meaningMaker.markerFound(marker);
@@ -113,6 +116,8 @@ describe('Meaning Maker', () => {
     const meaningMaker = await initMM();
     const url = new URL('/base/test-assets/test-image.html', window.location.href);
     await meaningMaker.loadArtifactsFromUrl(url);
+    const artifacts = await meaningMaker.loadArtifactsFromUrl(url);
+    assert.lengthOf(artifacts, 1);
 
     const detectedImage = {
       id: 'Lighthouse'
@@ -128,6 +133,29 @@ describe('Meaning Maker', () => {
     assert.equal(loseRespones.lost.length, 1);
   });
 
+  it('loads markers dynamically', async () => {
+    const meaningMaker = await initMM();
+    const url = new URL('/base/test-assets/test-dynamic.html', window.location.href);
+    // TODO: The following fails sometimes
+    assert.equal(url.port, '9876');
+
+    // Do not load artifact first.
+
+    const marker = {
+      type: 'qr_code',
+      value: url.href
+    };
+
+    const foundResponse = await meaningMaker.markerFound(marker);
+    assert.isDefined(foundResponse);
+    assert.equal(foundResponse.found.length, 1);
+    assert.equal(foundResponse.lost.length, 0);
+
+    const loseRespones = await meaningMaker.markerLost(marker);
+    assert.equal(loseRespones.found.length, 0);
+    assert.equal(loseRespones.lost.length, 1);
+  });
+
   it('accepts updated locations without any geofenced artifacts', async () => {
     // Location updates do not change results.
     const meaningMaker = await initMM();
@@ -136,12 +164,13 @@ describe('Meaning Maker', () => {
       longitude: 1
     };
 
-    const url = new URL('/base/test-assets/test1.html', window.location.href);
-    await meaningMaker.loadArtifactsFromUrl(url);
+    const url = new URL('/base/test-assets/test-barcode.html', window.location.href);
+    const artifacts = await meaningMaker.loadArtifactsFromUrl(url);
+    assert.lengthOf(artifacts, 1);
 
     const marker = {
       type: 'qr_code',
-      value: url.href
+      value: '1234567890'
     };
 
     // Add the marker.

--- a/src/elements/meaning-maker/meaning-maker_test.ts
+++ b/src/elements/meaning-maker/meaning-maker_test.ts
@@ -91,7 +91,7 @@ describe('Meaning Maker', () => {
     assert.equal(images.length, 1, 'No image artifacts');
   });
 
-  it('finds and loses barcodes', async () => {
+  it('finds and loses markers', async () => {
     const meaningMaker = await initMM();
     const url = new URL('/base/test-assets/test-barcode.html', window.location.href);
     const artifacts = await meaningMaker.loadArtifactsFromUrl(url);
@@ -133,7 +133,7 @@ describe('Meaning Maker', () => {
     assert.equal(loseRespones.lost.length, 1);
   });
 
-  it('loads markers dynamically', async () => {
+  it.skip('loads markers dynamically', async () => {
     const meaningMaker = await initMM();
     const url = new URL('/base/test-assets/test-dynamic.html', window.location.href);
     // TODO: The following fails sometimes

--- a/test-assets/test-barcode.html
+++ b/test-assets/test-barcode.html
@@ -27,13 +27,13 @@
       "@type": "ARArtifact",
       "arTarget": [{
         "@type": "Barcode",
-        "text": "http://localhost:9876/base/test-assets/test1.html"
+        "text": "1234567890"
       }],
       "arContent": {
         "@type": "WebPage",
-        "url": "http://localhost:9876/base/test-assets/test1.html",
+        "url": "http://localhost:9876/base/test-assets/test-barcode.html",
         "name": "Product 1",
-        "description": "This is a dynamic result",
+        "description": "This is a barcode result",
         "image": "http://localhost:9876/demo/dynamic-discovery/products/product1-qrcode.png"
       }
     }

--- a/test-assets/test-dynamic.html
+++ b/test-assets/test-dynamic.html
@@ -1,0 +1,45 @@
+<!--
+  @license
+  Copyright 2019 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="theme-color" content="#1A3230">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>Product 1</title>
+
+    <script type="application/ld+json">
+    {
+      "@context": "http://schema.org",
+      "@type": "ARArtifact",
+      "arTarget": [{
+        "@type": "Barcode",
+        "text": "http://localhost:9876/base/test-assets/test-dynamic.html"
+      }],
+      "arContent": {
+        "@type": "WebPage",
+        "url": "http://localhost:9876/base/test-assets/test-dynamic.html",
+        "name": "Product 1",
+        "description": "This is a dynamic result",
+        "image": "http://localhost:9876/demo/dynamic-discovery/products/product1-qrcode.png"
+      }
+    }
+    </script>
+  </head>
+<body>
+  Test 1
+</body>
+</html>


### PR DESCRIPTION
Instead of disabling flaky tests, I simplified MM tests to not depend on URL-specific qr-codes as the marker value.

I also added a dynamic discovery test that actually tests dynamic URL loading -- but left if disabled for now, until I figure how out how to adjust to rotating port number (or implement relative URL paths).