### PR TITLE
Configure tests with RAPID=true env variable

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-const debug = false;
+const debug = process.env.RAPID || false;
 
 module.exports = function(config) {
   const options = {


### PR DESCRIPTION
I got tired of editing karma config to add debug=true.

Now we can `RAPID=true npm run test`