### PR TITLE
Improve AritfactLoader test coverage to almost 100%

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -114,7 +114,8 @@ module.exports = function(config) {
     ],
 
     mime: {
-      'application/wasm': ['wasm']
+      'application/wasm': ['wasm'],
+      'application/ld+json': ['jsonld']
     },
 
     singleRun: !debug

--- a/src/artifacts/artifact-loader_test.ts
+++ b/src/artifacts/artifact-loader_test.ts
@@ -123,6 +123,24 @@ describe('ArtifactLoader', () => {
     assert.lengthOf(result, 2);
   });
 
+  it('handles bad HTML URLs', async () => {
+    const url = new URL('/bad.html', window.location.href);
+    try {
+      await artLoader.fromHtmlUrl(url);
+    } catch (e) {
+      assert.throws(() => { throw e; });
+    }
+  });
+
+  it('handles bad Json-ld URLs', async () => {
+    const url = new URL('/bad.jsonld', window.location.href);
+    try {
+      await artLoader.fromJsonUrl(url);
+    } catch (e) {
+      assert.throws(() => { throw e; });
+    }
+  });
+
   it('discovers artifacts from HTML pages, by URL', async () => {
     const url = new URL('/base/test-assets/test1.html', window.location.href);
     const artifacts = await artLoader.fromHtmlUrl(url);
@@ -137,13 +155,20 @@ describe('ArtifactLoader', () => {
     assert.lengthOf(artifacts, 1);
   });
 
+  it.skip('discovers artifacts from HTML pages with external scripts, by URL', async () => {
+    const url = new URL('/base/test-assets/test-external-ld.html', window.location.href);
+    const artifacts = await artLoader.fromHtmlUrl(url);
+    assert.isArray(artifacts);
+    assert.lengthOf(artifacts, 2);
+  });
+
   it('discovers artifacts from HTML pages, using URLs of unknown content type', async () => {
-    const url = new URL('/base/test-assets/dow.location.href');
+    const url = new URL('/base/test-assets/test1.html', window.location.href);
     const artifacts = await artLoader.fromUrl(url);
     assert.isArray(artifacts);
     assert.lengthOf(artifacts, 1);
   });
-  
+
   it('discovers artifacts from HTML pages, using URLs of unknown content type', async () => {
     const url = new URL('/base/test-assets/test-json.jsonld', window.location.href);
     const artifacts = await artLoader.fromUrl(url);

--- a/src/artifacts/artifact-loader_test.ts
+++ b/src/artifacts/artifact-loader_test.ts
@@ -122,4 +122,32 @@ describe('ArtifactLoader', () => {
     assert.isArray(result);
     assert.lengthOf(result, 2);
   });
+
+  it('discovers artifacts from HTML pages, by URL', async () => {
+    const url = new URL('/base/test-assets/test1.html', window.location.href);
+    const artifacts = await artLoader.fromHtmlUrl(url);
+    assert.isArray(artifacts);
+    assert.lengthOf(artifacts, 1);
+  });
+
+  it('discovers artifacts from JSON-LD documents, by URL', async () => {
+    const url = new URL('/base/test-assets/test-json.jsonld', window.location.href);
+    const artifacts = await artLoader.fromJsonUrl(url);
+    assert.isArray(artifacts);
+    assert.lengthOf(artifacts, 1);
+  });
+
+  it('discovers artifacts from HTML pages, using URLs of unknown content type', async () => {
+    const url = new URL('/base/test-assets/dow.location.href');
+    const artifacts = await artLoader.fromUrl(url);
+    assert.isArray(artifacts);
+    assert.lengthOf(artifacts, 1);
+  });
+  
+  it('discovers artifacts from HTML pages, using URLs of unknown content type', async () => {
+    const url = new URL('/base/test-assets/test-json.jsonld', window.location.href);
+    const artifacts = await artLoader.fromUrl(url);
+    assert.isArray(artifacts);
+    assert.lengthOf(artifacts, 1);
+  });
 });

--- a/src/artifacts/artifact-loader_test.ts
+++ b/src/artifacts/artifact-loader_test.ts
@@ -142,7 +142,7 @@ describe('ArtifactLoader', () => {
   });
 
   it('discovers artifacts from HTML pages, by URL', async () => {
-    const url = new URL('/base/test-assets/test1.html', window.location.href);
+    const url = new URL('/base/test-assets/test-barcode.html', window.location.href);
     const artifacts = await artLoader.fromHtmlUrl(url);
     assert.isArray(artifacts);
     assert.lengthOf(artifacts, 1);
@@ -163,7 +163,7 @@ describe('ArtifactLoader', () => {
   });
 
   it('discovers artifacts from HTML pages, using URLs of unknown content type', async () => {
-    const url = new URL('/base/test-assets/test1.html', window.location.href);
+    const url = new URL('/base/test-assets/test-barcode.html', window.location.href);
     const artifacts = await artLoader.fromUrl(url);
     assert.isArray(artifacts);
     assert.lengthOf(artifacts, 1);

--- a/test-assets/test-external-ld.html
+++ b/test-assets/test-external-ld.html
@@ -1,0 +1,32 @@
+<!--
+  @license
+  Copyright 2019 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="theme-color" content="#1A3230">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>Lighthouse</title>
+
+    <link rel="alternate" type="application/ld+json" href="http://localhost:9876/base/test-assets/test-json.jsonld" />
+    <link rel="alternate" type="application/ld+json" />
+    <script type="application/ld+json" src="http://localhost:9876/base/test-assets/test-json.jsonld"></script>
+    <script type="application/ld+json"></script>
+  </head>
+<body>
+  Test Image
+</body>
+</html>

--- a/test-assets/test-json.jsonld
+++ b/test-assets/test-json.jsonld
@@ -6,6 +6,6 @@
     "text": "1234567890"
   }],
   "arContent": {
-    "@type": "WebPage",
+    "@type": "WebPage"
   }
 }

--- a/test-assets/test-json.jsonld
+++ b/test-assets/test-json.jsonld
@@ -1,0 +1,11 @@
+{
+  "@context": "https://schema.googleapis.com",
+  "@type": "ARArtifact",
+  "arTarget": [{
+    "@type": "Barcode",
+    "text": "1234567890"
+  }],
+  "arContent": {
+    "@type": "WebPage",
+  }
+}


### PR DESCRIPTION
One of the tests is temporarily skipped because it relies on karma port number (similar to MM test).

Will re-enable it once relative URLs are supported.